### PR TITLE
Fix typo. ruby -> Ruby.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## ARL 
+## ARL
 ###### *(Another Repository List)*
 Well, one of the best ways to learn something new is to watch how it is done by others.
 
@@ -13,7 +13,7 @@ Below is the list of lists of most popular repositories, sorted by number of sta
  * [NodeJS](https://github.com/kaxap/arl/blob/master/README-Node.md)
  * [C#](https://github.com/kaxap/arl/blob/master/README-CSharp.md)
  * [PHP](https://github.com/kaxap/arl/blob/master/README-PHP.md)
- * [Ruby](https://github.com/kaxap/arl/blob/master/README-ruby.md)
+ * [Ruby](https://github.com/kaxap/arl/blob/master/README-Ruby.md)
  * [TypeScript](https://github.com/kaxap/arl/blob/master/README-TypeScript.md)
  * [Swift](https://github.com/kaxap/arl/blob/master/README-Swift.md)
  * [Objective-C](https://github.com/kaxap/arl/blob/master/README-ObjectiveC.md)


### PR DESCRIPTION
Correct typo which ruby should be Ruby in `README.md`.